### PR TITLE
Support for building with nmake and VC++

### DIFF
--- a/tests/get.test
+++ b/tests/get.test
@@ -93,7 +93,7 @@ test get-3.1 {free} -body { #<<<
 	lappend ::res	[info exists ::cx]
 } -cleanup {
 	unset -nocomplain ::cx ::res val intrep
-} -result {0 {get-3.1: はval-3.1x} 1 0}
+} -result [list 0 "get-3.1: \u306fval-3.1x" 1 0]
 #>>>
 test get-4.1 {type context arg - emulate Tcl_GetIndexFromObj with unique prefix matching} -setup { #<<<
 	type::define get-4.1 {

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -1,6 +1,6 @@
 #------------------------------------------------------------- -*- makefile -*-
 #
-# Sample makefile for building Tcl extensions.
+# Makefile for type using nmake and Visual C++
 #
 # Basic build, test and install
 #   nmake /s /nologo /f makefile.vc INSTALLDIR=c:\path\to\tcl
@@ -17,7 +17,7 @@
 #------------------------------------------------------------------------------
 
 # The name of the package
-PROJECT = sample
+PROJECT = type
 
 !include "rules-ext.vc"
 
@@ -26,19 +26,21 @@ PROJECT = sample
 # hence it is under that condition. TMP_DIR is the output directory
 # defined by rules for object files.
 PRJ_OBJS = \
-	$(TMP_DIR)\tclsample.obj \
-	$(TMP_DIR)\sample.obj
+	$(TMP_DIR)\type.obj \
+	$(TMP_DIR)\names.obj
 
 # Define any additional compiler flags that might be required for the project
 PRJ_DEFINES = -D_CRT_SECURE_NO_DEPRECATE
+#if $(TCL_MAJOR_VERSION) == 8 && $(TCL_MINOR_VERSION) < 7
+PRJ_DEFINES = -DTIP445_SHIM=1
+#endif
 
 # Define the standard targets
 !include "$(_RULESDIR)\targets.vc"
 
 # We must define a pkgindex target that will create a pkgIndex.tcl
-# file in the $(OUT_DIR) directory. We can just redirect to the
-# default-pkgindex target for our sample extension.
-pkgindex: default-pkgindex
+# file in the $(OUT_DIR) directory. We can just reuse the TEA one.
+pkgindex: default-pkgindex-tea
 
 # The default install target only installs binaries and scripts so add
 # an additional target for our documentation. Note this *adds* a target


### PR DESCRIPTION
Added support for building the extension with nmake/VC++.

I also made a change for test get-3.1 which was failing on Windows (both with TEA/gcc as well as nmake/vc++) because the test scripts are not read in as utf-8. However I am not sure the change I made preserves your original intent. Please verify it does not change the test semantics.